### PR TITLE
Fix exception when no output format is specified

### DIFF
--- a/tester/rt/test.py
+++ b/tester/rt/test.py
@@ -345,6 +345,8 @@ def run(args, command_path = None):
                 raise error.general('invalid RTEMS report formats option')
             report_formats = report_formats[1].split(',')
             check_report_formats(report_formats, report_location)
+        else:
+            report_formats = []
         log.notice('RTEMS Testing - Tester, %s' % (version.string()))
         if opts.find_arg('--list-bsps'):
             bsps.list(opts)


### PR DESCRIPTION
The JSON log generation patch introduced a bug when the report output
generation was not configured due to attempting to iterate over 'None'.